### PR TITLE
Fix build script

### DIFF
--- a/Linux_for_Tegra/source/public/nvbuild.sh
+++ b/Linux_for_Tegra/source/public/nvbuild.sh
@@ -90,7 +90,10 @@ function build_arm64_kernel_sources {
 		CROSS_COMPILE="${CROSS_COMPILE_AARCH64}" \
 		"${O_OPT[@]}" "${config_file}"
 
-	"${MAKE_BIN}" -C "${source_dir}" menuconfig ARCH=arm64 "${O_OPT[@]}"
+	"${MAKE_BIN}" -C "${source_dir}" ARCH=arm64 \
+		LOCALVERSION="-tegra" \
+		CROSS_COMPILE="${CROSS_COMPILE_AARCH64}" \
+		"${O_OPT[@]}" menuconfig
 
 	"${MAKE_BIN}" -C "${source_dir}" ARCH=arm64 \
 		LOCALVERSION="-tegra" \


### PR DESCRIPTION
Fix script for building the kernel when used in a kernel version different than the built one.